### PR TITLE
Update build workflow to use hashicorp packer action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,17 +11,18 @@ jobs:
       - name: Checkout Packer project
         uses: actions/checkout@v2
 
-      - name: Packer Init
+      - name: Export Application Credentials
         run: |
-          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-          sudo apt-get update && sudo apt-get install packer
-          packer init .
-
-      - name: Build Packer Artifact
+          echo ${PACKER_SA_KEY} > $GOOGLE_APPLICATION_CREDENTIALS
         env:
           PACKER_SA_KEY: ${{ secrets.PACKER_SA_KEY }}
           GOOGLE_APPLICATION_CREDENTIALS: /home/runner/packer_sa_key.json
-        run: |
-          echo ${PACKER_SA_KEY} > /home/runner/packer_sa_key.json
-          packer build -var="ghrunner_version=$GITHUB_REF_NAME" -var-file="runtime-variables.pkrvars.hcl" .
+
+      - name: Build Artifact
+        uses: hashicorp/packer-github-actions@master
+        with:
+          command: build
+          arguments: "-var=ghrunner_version=$GITHUB_REF_NAME -var-file=runtime-variables.pkrvars.hcl"
+          target: .
+        env:
+          PACKER_LOG: 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,9 +13,8 @@ jobs:
 
       - name: Export Application Credentials
         run: |
-          echo ${PACKER_SA_KEY} > $GOOGLE_APPLICATION_CREDENTIALS
+          echo ${{ secrets.PACKER_SA_KEY }} > $GOOGLE_APPLICATION_CREDENTIALS
         env:
-          PACKER_SA_KEY: ${{ secrets.PACKER_SA_KEY }}
           GOOGLE_APPLICATION_CREDENTIALS: /home/runner/packer_sa_key.json
 
       - name: Initialize Packer Plugin Binaries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,11 +18,15 @@ jobs:
           PACKER_SA_KEY: ${{ secrets.PACKER_SA_KEY }}
           GOOGLE_APPLICATION_CREDENTIALS: /home/runner/packer_sa_key.json
 
+      - name: Initialize Packer Plugin Binaries
+        uses: hashicorp/packer-github-actions@master
+        with:
+          command: init
+          target: .
+
       - name: Build Artifact
         uses: hashicorp/packer-github-actions@master
         with:
           command: build
           arguments: "-var=ghrunner_version=$GITHUB_REF_NAME -var-file=runtime-variables.pkrvars.hcl"
           target: .
-        env:
-          PACKER_LOG: 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,8 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Export Application Credentials
-        run: |
-          echo ${{ secrets.PACKER_SA_KEY }} > $GOOGLE_APPLICATION_CREDENTIALS
+        run: echo ${{ secrets.PACKER_SA_KEY }} > $GOOGLE_APPLICATION_CREDENTIALS
         env:
           GOOGLE_APPLICATION_CREDENTIALS: /home/runner/packer_sa_key.json
 


### PR DESCRIPTION
fixes #5 

This PR Updates the Validate step in the `.github/workflows/build.yaml` file to use the build Packer action at [ https://github.com/hashicorp/packer-github-actions]( https://github.com/hashicorp/packer-github-actions)