### PR TITLE
Install sudo in all images

### DIFF
--- a/scripts/setup_with_nvidia.sh
+++ b/scripts/setup_with_nvidia.sh
@@ -5,9 +5,9 @@ export DEBIAN_FRONTEND=noninteractive
 echo "[INFO] > Disable unattended upgrades services"
 systemctl disable --now unattended-upgrades.service
 
-echo "[INFO] > Prepare the system before installing drivers"
+echo "[INFO] > Install base packages"
 apt-get update
-apt-get install -y build-essential ubuntu-drivers-common
+apt-get install -y sudo build-essential ubuntu-drivers-common
 
 echo "[INFO] > Installing NVIDIA drivers"
 ubuntu-drivers autoinstall
@@ -17,6 +17,7 @@ apt autoremove -y
 echo "[INFO] > Creating user runner with home directory"
 /usr/sbin/useradd -m runner
 mkdir ~runner/runner
+echo "runner ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/runner
 
 echo "[INFO] > Installing GitHub Actions runner"
 curl -fsSL https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz | tar -C ~runner/runner -xzf -

--- a/scripts/setup_without_nvidia.sh
+++ b/scripts/setup_without_nvidia.sh
@@ -5,9 +5,14 @@ export DEBIAN_FRONTEND=noninteractive
 echo "[INFO] > Disable unattended upgrades services"
 systemctl disable --now unattended-upgrades.service
 
+echo "[INFO] > Install base packages"
+apt-get update
+apt-get install -y sudo
+
 echo "[INFO] > Creating user runner with home directory"
 /usr/sbin/useradd -m runner
 mkdir ~runner/runner
+echo "runner ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/runner
 
 echo "[INFO] > Installing GitHub Actions runner"
 curl -fsSL https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz | tar -C ~runner/runner -xzf -


### PR DESCRIPTION
This PR adds the `sudo` package in all images and configures it for password-less access by the `runner` user.
Having `sudo` properly configured is necessary for many actions that set tools up.