### PR TITLE
adjust filter name to get latest image

### DIFF
--- a/aws/amd64/values.pkrvars.hcl
+++ b/aws/amd64/values.pkrvars.hcl
@@ -1,4 +1,4 @@
-source_image            = "Deep Learning AMI GPU TensorFlow 2.8.2 (Ubuntu 20.04) 20220731"
+source_image            = "Deep Learning Driver AMI GPU (Ubuntu 20.04)"
 instance_type           = "g4dn.2xlarge"
 arch                    = "amd64"
 nvidia_major_version    = "510"


### PR DESCRIPTION
Expected ami for new run should be

- Deep Learning OSS Nvidia Driver AMI GPU TensorFlow 2.16 (Ubuntu 20.04) 20240806 (ami-08ef0be8e061f0c3f)